### PR TITLE
feat: add nix flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target/
 *.png
 *.json
 .run/
+
+# direnv
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1738652123,
+        "narHash": "sha256-zdZek5FXK/k95J0vnLF0AMnYuZl4AjARq83blKuJBYY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "c7e015a5fcefb070778c7d91734768680188a9cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738703096,
+        "narHash": "sha256-1MABVDwNpAUrUDvyM6PlHlAB1eTWAX0eNYCzdsZ54NI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f7384aacd0ecd28681a99269ac0dff2c3a805d63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738722444,
+        "narHash": "sha256-DHVyKCiIQVDqjYoVU2j7UaLNIlOnpB9sP1cPRNRpqvY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "347fb01821c3cd8d54e563d244a599c1e27a393d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,154 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      flake-utils,
+      nixpkgs,
+      rust-overlay,
+      crane,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        filteredSource =
+          let
+            pathsToIgnore = [
+              ".envrc"
+              ".ignore"
+              ".github"
+              ".gitignore"
+              "rust-toolchain.toml"
+              "README.MD"
+              "flake.nix"
+              "flake.lock"
+              "target"
+              "LICENCE"
+              ".direnv"
+            ];
+            ignorePaths =
+              path: type:
+              let
+                inherit (nixpkgs) lib;
+                # split the nix store path into its components
+                components = lib.splitString "/" path;
+                # drop off the `/nix/hash-source` section from the path
+                relPathComponents = lib.drop 4 components;
+                # reassemble the path components
+                relPath = lib.concatStringsSep "/" relPathComponents;
+              in
+              lib.all (p: !(lib.hasPrefix p relPath)) pathsToIgnore;
+          in
+          builtins.path {
+            name = "mania-source";
+            path = toString ./.;
+            # filter out unnecessary paths
+            filter = ignorePaths;
+          };
+        stdenv = if pkgs.stdenv.isLinux then pkgs.stdenv else pkgs.clangStdenv;
+        rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+        commonArgs = {
+          inherit stdenv;
+          inherit
+            (craneLib.crateNameFromCargoToml {
+              cargoToml = ./mania/Cargo.toml;
+            })
+            pname
+            ;
+          inherit
+            (craneLib.crateNameFromCargoToml {
+              cargoToml = ./Cargo.toml;
+            })
+            version
+            ;
+          src = filteredSource;
+          strictDeps = true;
+          nativeBuildInputs = [
+            pkgs.protobuf
+          ];
+          doCheck = false;
+          meta = {
+            mainProgram = "mania";
+            homepage = "https://github.com/LagrangeDev/mania";
+            license = pkgs.lib.licenses.gpl3Only;
+          };
+        };
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+      in
+      {
+        packages = {
+          mania = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs = ''
+                --example multi-login
+              '';
+              postInstall = ''
+                mkdir -p $out/bin
+
+                cp ./target/release/examples/multi-login $out/bin/mania
+              '';
+            }
+          );
+          default = self.packages."${system}".mania;
+        };
+        checks = {
+          inherit (self.packages."${system}") mania;
+          clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            }
+          );
+          fmt = craneLib.cargoFmt commonArgs;
+          doc = craneLib.cargoDoc (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
+          test = craneLib.cargoTest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
+        };
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+            rust-analyzer
+          ];
+          nativeBuildInputs = with pkgs; [ protobuf ];
+        };
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        inherit (self.packages."${final.system}") mania;
+      };
+    };
+
+}


### PR DESCRIPTION
as the title: add nix flake support

- add flake.nix which export:
  - packages (now only example)
  - overlays
  - checks:
    - packages
    - test
    - doc
    - fmt
    - clippy
  - devShell
- add .envrc for integration with direnv