### PR TITLE
feat: refine nix integration with development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
-use flake
+watch_file flake.lock
+watch_file rust-toolchain.toml
+
+use flake || use nix
+eval "$shellHook"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+# use flake's packages.default for non-flake-enabled nix instances
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nodeName = lock.nodes.root.inputs.flake-compat;
+  compat = fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  };
+in
+(import compat { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,21 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -69,6 +84,7 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
       url = "github:rustsec/advisory-db";
       flake = false;
     };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+    };
   };
 
   outputs =
@@ -148,11 +151,14 @@
           );
         };
         devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks."${system}";
           packages = with pkgs; [
-            (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
             rust-analyzer
+            cargo-flamegraph
+            cargo-tarpaulin
+            lldb
           ];
-          nativeBuildInputs = with pkgs; [ protobuf ];
+          shellHook = '''';
         };
       }
     )
@@ -161,5 +167,4 @@
         inherit (self.packages."${final.system}") mania;
       };
     };
-
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+# use flake's devShells.default for non-flake-enabled nix instances
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nodeName = lock.nodes.root.inputs.flake-compat;
+  compat = fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  };
+in
+(import compat { src = ./.; }).shellNix.default


### PR DESCRIPTION
as the title: refine the integration with nix and direnv.

- add `shell.nix` and `default.nix` to ensure non-flake-enabled nix instance can use flake's `devShells` and `packages` via [flake-compat](https://github.com/edolstra/flake-compat).
- add `watch_file` directive in `.envrc` for watch the change of `rust-toolchain.toml` and `flake.lock`, for making sure direnv activate the newest development environment.
- use `use flake || use nix` in `.envrc` to fallback to `nix-shell` when `flake` disabled.