### PR TITLE
feat: add dependabot for updating cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # TODO: wait for refactor the related code
+    ignore:
+      - dependency-name: rand
+      - dependency-name: rand_chacha
+      - dependency-name: elliptic-curve
+      - dependency-name: p256

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,18 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "examples"
-version = "0.0.1"
-dependencies = [
- "cfg-if",
- "console-subscriber",
- "mania",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1240,18 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "mania-examples"
+version = "0.0.1"
+dependencies = [
+ "cfg-if",
+ "console-subscriber",
+ "mania",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "mania-examples"
 description = "examples for mania"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
as the title: add dependabot for updating cargo dependencies monthly

- add `.github/dependabot.yml` for config dependabot.
- rename `examples` package name because `examples` is forbidden to be a package name in cargo.