### PR TITLE
fix: optimize the Cargo.toml of macro crate

### DIFF
--- a/mania-macros/Cargo.toml
+++ b/mania-macros/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "mania-macros"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
as the title: optimize the manifest of `mania-macros`

- set `edition` to follow the workspace.
- set `version` to follow the workspace.
- add `license-file` option and set it to follow the workspace.