### PR TITLE
feat: bump rust `edition`: 2021 -> 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["mania", "mania-macros", "examples"]
 
 [workspace.package]
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 license-file = "LICENCE"
 
 [workspace.dependencies]

--- a/mania-macros/src/lib.rs
+++ b/mania-macros/src/lib.rs
@@ -2,7 +2,7 @@ use md5::{Digest, Md5};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    parse_macro_input, punctuated::Punctuated, DeriveInput, ItemFn, ItemStruct, LitStr, Path,
+    DeriveInput, ItemFn, ItemStruct, LitStr, Path, parse_macro_input, punctuated::Punctuated,
 };
 
 #[proc_macro_attribute]

--- a/mania/src/core/business.rs
+++ b/mania/src/core/business.rs
@@ -203,11 +203,11 @@ impl BusinessHandle {
         // PushMessageEvent, ... -> Lagrange.Core.Internal.Context.Logic.Implementation.MessagingLogic.Incoming
         dispatch_logic(&mut *event, self.clone(), LogicFlow::InComing).await;
         // TODO: timeout auto remove
-        if let Some((_, tx)) = self.pending_requests.remove(&sequence) {
+        match self.pending_requests.remove(&sequence) { Some((_, tx)) => {
             tx.send(event).unwrap();
-        } else {
+        } _ => {
             tracing::warn!("unhandled packet: {:?}", event);
-        }
+        }}
         Ok(())
     }
 

--- a/mania/src/core/business.rs
+++ b/mania/src/core/business.rs
@@ -20,7 +20,7 @@ use crate::core::socket::{self, PacketReceiver, PacketSender};
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
-use tokio::sync::{oneshot, Mutex, MutexGuard};
+use tokio::sync::{Mutex, MutexGuard, oneshot};
 
 #[derive(Copy, Clone, Debug)]
 pub enum LogicFlow {
@@ -139,7 +139,9 @@ impl Business {
         self.handle.sender.store(Arc::new(sender));
         self.receiver = receiver;
 
-        todo!("await Collection.Business.WtExchangeLogic.BotOnline(BotOnlineEvent.OnlineReason.Reconnect);")
+        todo!(
+            "await Collection.Business.WtExchangeLogic.BotOnline(BotOnlineEvent.OnlineReason.Reconnect);"
+        )
     }
 
     async fn reconnect(&mut self) {
@@ -203,11 +205,14 @@ impl BusinessHandle {
         // PushMessageEvent, ... -> Lagrange.Core.Internal.Context.Logic.Implementation.MessagingLogic.Incoming
         dispatch_logic(&mut *event, self.clone(), LogicFlow::InComing).await;
         // TODO: timeout auto remove
-        match self.pending_requests.remove(&sequence) { Some((_, tx)) => {
-            tx.send(event).unwrap();
-        } _ => {
-            tracing::warn!("unhandled packet: {:?}", event);
-        }}
+        match self.pending_requests.remove(&sequence) {
+            Some((_, tx)) => {
+                tx.send(event).unwrap();
+            }
+            _ => {
+                tracing::warn!("unhandled packet: {:?}", event);
+            }
+        }
         Ok(())
     }
 

--- a/mania/src/core/business.rs
+++ b/mania/src/core/business.rs
@@ -205,13 +205,10 @@ impl BusinessHandle {
         // PushMessageEvent, ... -> Lagrange.Core.Internal.Context.Logic.Implementation.MessagingLogic.Incoming
         dispatch_logic(&mut *event, self.clone(), LogicFlow::InComing).await;
         // TODO: timeout auto remove
-        match self.pending_requests.remove(&sequence) {
-            Some((_, tx)) => {
-                tx.send(event).unwrap();
-            }
-            _ => {
-                tracing::warn!("unhandled packet: {:?}", event);
-            }
+        if let Some((_, tx)) = self.pending_requests.remove(&sequence) {
+            tx.send(event).unwrap();
+        } else {
+            tracing::warn!("unhandled packet: {:?}", event);
         }
         Ok(())
     }

--- a/mania/src/core/business/messaging_logic.rs
+++ b/mania/src/core/business/messaging_logic.rs
@@ -34,7 +34,7 @@ async fn messaging_logic_incoming(
                 Some(chain) => {
                     for entity in &mut chain.entities {
                         match entity {
-                            Entity::Image(ref mut image) => {
+                            &mut Entity::Image(ref mut image) => {
                                 if !image.url.contains("&rkey=") {
                                     continue;
                                 }
@@ -65,7 +65,7 @@ async fn messaging_logic_incoming(
                                     }
                                 }
                             }
-                            Entity::MultiMsg(ref mut multi) => match multi.chains.is_empty() {
+                            &mut Entity::MultiMsg(ref mut multi) => match multi.chains.is_empty() {
                                 true => {
                                     let msg = handle
                                         .multi_msg_download(chain.uid.clone(), multi.res_id.clone())
@@ -86,7 +86,7 @@ async fn messaging_logic_incoming(
                                 }
                                 false => {}
                             },
-                            Entity::File(ref mut file) => {
+                            &mut Entity::File(ref mut file) => {
                                 file.file_url = match file.extra.as_ref() {
                                     Some(extra) => match extra {
                                         FileUnique::Group(grp) => {
@@ -121,7 +121,7 @@ async fn messaging_logic_incoming(
                                     _ => None,
                                 }
                             }
-                            Entity::Record(ref mut record) => {
+                            &mut Entity::Record(ref mut record) => {
                                 let node = || -> Option<_> {
                                     record
                                         .msg_info

--- a/mania/src/core/business/messaging_logic.rs
+++ b/mania/src/core/business/messaging_logic.rs
@@ -33,8 +33,8 @@ async fn messaging_logic_incoming(
             match &mut msg.chain {
                 Some(chain) => {
                     for entity in &mut chain.entities {
-                        match entity {
-                            &mut Entity::Image(ref mut image) => {
+                        match *entity {
+                            Entity::Image(ref mut image) => {
                                 if !image.url.contains("&rkey=") {
                                     continue;
                                 }
@@ -65,7 +65,7 @@ async fn messaging_logic_incoming(
                                     }
                                 }
                             }
-                            &mut Entity::MultiMsg(ref mut multi) => match multi.chains.is_empty() {
+                            Entity::MultiMsg(ref mut multi) => match multi.chains.is_empty() {
                                 true => {
                                     let msg = handle
                                         .multi_msg_download(chain.uid.clone(), multi.res_id.clone())
@@ -86,7 +86,7 @@ async fn messaging_logic_incoming(
                                 }
                                 false => {}
                             },
-                            &mut Entity::File(ref mut file) => {
+                            Entity::File(ref mut file) => {
                                 file.file_url = match file.extra.as_ref() {
                                     Some(extra) => match extra {
                                         FileUnique::Group(grp) => {
@@ -121,7 +121,7 @@ async fn messaging_logic_incoming(
                                     _ => None,
                                 }
                             }
-                            &mut Entity::Record(ref mut record) => {
+                            Entity::Record(ref mut record) => {
                                 let node = || -> Option<_> {
                                     record
                                         .msg_info

--- a/mania/src/core/business/messaging_logic.rs
+++ b/mania/src/core/business/messaging_logic.rs
@@ -5,8 +5,8 @@ use crate::core::event::prelude::*;
 use crate::core::event::system::alive::AliveEvent;
 use crate::core::event::system::info_sync::InfoSyncEvent;
 use crate::message::chain::MessageType;
-use crate::message::entity::file::FileUnique;
 use crate::message::entity::Entity;
+use crate::message::entity::file::FileUnique;
 use mania_macros::handle_event;
 use std::sync::Arc;
 

--- a/mania/src/core/context.rs
+++ b/mania/src/core/context.rs
@@ -153,7 +153,7 @@ impl ExtendUuid for Uuid {
 impl Default for DeviceInfo {
     fn default() -> Self {
         let mut rng = rand::thread_rng();
-        let mac_address: Vec<u8> = (0..6).map(|_| rng.gen()).collect();
+        let mac_address: Vec<u8> = (0..6).map(|_| rng.r#gen()).collect();
         Self {
             uuid: Uuid::new_v4(),
             mac_address,

--- a/mania/src/core/crypto.rs
+++ b/mania/src/core/crypto.rs
@@ -1,5 +1,5 @@
 use md5::{Digest, Md5};
-use p256::{ecdh::EphemeralSecret, EncodedPoint, PublicKey};
+use p256::{EncodedPoint, PublicKey, ecdh::EphemeralSecret};
 
 pub mod consts;
 pub mod tea;

--- a/mania/src/core/crypto/tea.rs
+++ b/mania/src/core/crypto/tea.rs
@@ -1,8 +1,8 @@
 // copy from https://github.com/zkonge/rtea
 use byteorder::{BigEndian, ByteOrder};
-pub use generic_array::typenum::U16;
 pub use generic_array::GenericArray;
-use rand::{thread_rng, RngCore};
+pub use generic_array::typenum::U16;
+use rand::{RngCore, thread_rng};
 
 pub fn tea_encrypt(text: &[u8], key: &[u8]) -> Vec<u8> {
     let fill_count = 9 - (text.len() + 1) % 8;

--- a/mania/src/core/event.rs
+++ b/mania/src/core/event.rs
@@ -108,13 +108,13 @@ pub(crate) mod prelude {
         CECommandMarker, ClientEvent, ClientEventRegistry, EventError, ServerEvent,
     };
     pub use crate::core::packet::{
-        BinaryPacket, OidbPacket, PacketBuilder, PacketError, PacketReader, PacketType,
-        PREFIX_LENGTH_ONLY, PREFIX_U16, PREFIX_U8, PREFIX_WITH,
+        BinaryPacket, OidbPacket, PREFIX_LENGTH_ONLY, PREFIX_U8, PREFIX_U16, PREFIX_WITH,
+        PacketBuilder, PacketError, PacketReader, PacketType,
     };
     pub use crate::dda;
     pub use bytes::Bytes;
     pub use inventory;
-    pub use mania_macros::{commend, ServerEvent};
+    pub use mania_macros::{ServerEvent, commend};
     pub use num_enum::TryFromPrimitive;
     pub use prost::Message;
     pub use std::convert::TryFrom;

--- a/mania/src/core/event/message/multi_msg_download.rs
+++ b/mania/src/core/event/message/multi_msg_download.rs
@@ -5,7 +5,7 @@ use crate::core::protos::message::{
 use crate::message::chain::MessageChain;
 use crate::message::packer::MessagePacker;
 use crate::utility::compress::gzip;
-use mania_macros::{commend, ServerEvent};
+use mania_macros::{ServerEvent, commend};
 
 #[commend("trpc.group.long_msg_interface.MsgService.SsoRecvLongMsg")]
 #[derive(Debug, ServerEvent, Default)]

--- a/mania/src/core/key_store.rs
+++ b/mania/src/core/key_store.rs
@@ -66,7 +66,7 @@ pub(crate) struct WtLoginSession {
 }
 
 mod serde_rwlock {
-    use serde::{de, ser, Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, de, ser};
     use tokio::sync::RwLock;
 
     pub fn serialize<T, S>(value: &RwLock<T>, serializer: S) -> Result<S::Ok, S::Error>

--- a/mania/src/core/operation/login.rs
+++ b/mania/src/core/operation/login.rs
@@ -45,7 +45,7 @@ impl BusinessHandle {
     }
 
     async fn query_trans_tmp_status(self: &Arc<Self>) -> crate::Result<TransEmp12Res> {
-        if let Some(qr_sign) = &*self.context.session.qr_sign.load() {
+        match &*self.context.session.qr_sign.load() { Some(qr_sign) => {
             let request_body = NTLoginHttpRequest {
                 appid: self.context.app_info.app_id as u64,
                 qrsig: qr_sign.string.clone(),
@@ -71,9 +71,9 @@ impl BusinessHandle {
             } else {
                 panic!("Emp12 not found in response");
             }
-        } else {
+        } _ => {
             Err(Error::GenericError("QR code not fetched".into()))
-        }
+        }}
     }
 
     async fn do_wt_login(self: &Arc<Self>) -> crate::Result<()> {

--- a/mania/src/core/operation/login.rs
+++ b/mania/src/core/operation/login.rs
@@ -45,35 +45,34 @@ impl BusinessHandle {
     }
 
     async fn query_trans_tmp_status(self: &Arc<Self>) -> crate::Result<TransEmp12Res> {
-        match &*self.context.session.qr_sign.load() {
-            Some(qr_sign) => {
-                let request_body = NTLoginHttpRequest {
-                    appid: self.context.app_info.app_id as u64,
-                    qrsig: qr_sign.string.clone(),
-                    face_update_time: 0,
-                };
-                let payload = serde_json::to_vec(&request_body).unwrap();
-                let response = http::client()
-                    .post_binary_async(
-                        "https://ntlogin.qq.com/qr/getFace",
-                        &payload,
-                        "application/json",
-                    )
-                    .await
-                    .unwrap();
-                let info: NTLoginHttpResponse = serde_json::from_slice(&response).unwrap();
-                self.context.key_store.uin.store(info.uin.into());
-                let mut query_result = TransEmp::new_query_result();
-                let res = self.send_event(&mut query_result).await?;
-                let res: &TransEmp = downcast_event(&res).unwrap();
-                let result = res.result.as_ref().unwrap();
-                if let TransEmpResult::Emp12(emp12) = result {
-                    Ok(emp12.to_owned())
-                } else {
-                    panic!("Emp12 not found in response");
-                }
+        if let Some(qr_sign) = (*self.context.session.qr_sign.load()).clone() {
+            let request_body = NTLoginHttpRequest {
+                appid: self.context.app_info.app_id as u64,
+                qrsig: qr_sign.string.clone(),
+                face_update_time: 0,
+            };
+            let payload = serde_json::to_vec(&request_body).unwrap();
+            let response = http::client()
+                .post_binary_async(
+                    "https://ntlogin.qq.com/qr/getFace",
+                    &payload,
+                    "application/json",
+                )
+                .await
+                .unwrap();
+            let info: NTLoginHttpResponse = serde_json::from_slice(&response).unwrap();
+            self.context.key_store.uin.store(info.uin.into());
+            let mut query_result = TransEmp::new_query_result();
+            let res = self.send_event(&mut query_result).await?;
+            let res: &TransEmp = downcast_event(&res).unwrap();
+            let result = res.result.as_ref().unwrap();
+            if let TransEmpResult::Emp12(emp12) = result {
+                Ok(emp12.to_owned())
+            } else {
+                panic!("Emp12 not found in response");
             }
-            _ => Err(Error::GenericError("QR code not fetched".into())),
+        } else {
+            Err(Error::GenericError("QR code not fetched".into()))
         }
     }
 

--- a/mania/src/core/packet.rs
+++ b/mania/src/core/packet.rs
@@ -273,15 +273,21 @@ impl SsoPacket {
                         p.section(|p| p.string(&self.command)) // command
                             .section(|p| p) // unknown
                             .section(|p| {
-                                p.bytes(&match ctx.key_store.uid.load().as_ref().map(|arc| arc.to_string())
-                                { Some(ref uid) => {
-                                    let uid = NtPacketUid {
-                                        uid: Some(uid.clone()),
-                                    };
-                                    uid.encode_to_vec()
-                                } _ => {
-                                    Vec::new()
-                                }})
+                                p.bytes(&match ctx
+                                    .key_store
+                                    .uid
+                                    .load()
+                                    .as_ref()
+                                    .map(|arc| arc.to_string())
+                                {
+                                    Some(ref uid) => {
+                                        let uid = NtPacketUid {
+                                            uid: Some(uid.clone()),
+                                        };
+                                        uid.encode_to_vec()
+                                    }
+                                    _ => Vec::new(),
+                                })
                             }) // uid
                     })
                     .section(|p| p.bytes(&self.payload.0)) // payload

--- a/mania/src/core/packet.rs
+++ b/mania/src/core/packet.rs
@@ -273,20 +273,13 @@ impl SsoPacket {
                         p.section(|p| p.string(&self.command)) // command
                             .section(|p| p) // unknown
                             .section(|p| {
-                                p.bytes(&match ctx
-                                    .key_store
-                                    .uid
-                                    .load()
-                                    .as_ref()
-                                    .map(|arc| arc.to_string())
-                                {
-                                    Some(ref uid) => {
-                                        let uid = NtPacketUid {
-                                            uid: Some(uid.clone()),
-                                        };
-                                        uid.encode_to_vec()
-                                    }
-                                    _ => Vec::new(),
+                                p.bytes(&if let Some(uid) = ctx.key_store.uid.load().as_deref() {
+                                    let uid = NtPacketUid {
+                                        uid: Some(uid.clone()),
+                                    };
+                                    uid.encode_to_vec()
+                                } else {
+                                    Vec::new()
                                 })
                             }) // uid
                     })

--- a/mania/src/core/packet.rs
+++ b/mania/src/core/packet.rs
@@ -273,16 +273,15 @@ impl SsoPacket {
                         p.section(|p| p.string(&self.command)) // command
                             .section(|p| p) // unknown
                             .section(|p| {
-                                p.bytes(&if let Some(ref uid) =
-                                    ctx.key_store.uid.load().as_ref().map(|arc| arc.to_string())
-                                {
+                                p.bytes(&match ctx.key_store.uid.load().as_ref().map(|arc| arc.to_string())
+                                { Some(ref uid) => {
                                     let uid = NtPacketUid {
                                         uid: Some(uid.clone()),
                                     };
                                     uid.encode_to_vec()
-                                } else {
+                                } _ => {
                                     Vec::new()
-                                })
+                                }})
                             }) // uid
                     })
                     .section(|p| p.bytes(&self.payload.0)) // payload
@@ -412,12 +411,12 @@ fn random_trace() -> String {
 
     // 32 digits
     for _ in 0..16 {
-        write!(result, "{:x}", rng.gen::<u8>()).unwrap();
+        write!(result, "{:x}", rng.r#gen::<u8>()).unwrap();
     }
     result.push('-');
     // 16 digits
     for _ in 0..8 {
-        write!(result, "{:x}", rng.gen::<u8>()).unwrap();
+        write!(result, "{:x}", rng.r#gen::<u8>()).unwrap();
     }
     result.push_str("-01");
 

--- a/mania/src/core/ping.rs
+++ b/mania/src/core/ping.rs
@@ -2,7 +2,7 @@ use std::io::Result;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use surge_ping::{Client, Config, PingIdentifier, PingSequence, ICMP};
+use surge_ping::{Client, Config, ICMP, PingIdentifier, PingSequence};
 
 /// Ping a list of addresses and return the latency.
 pub async fn ping(addrs: Vec<SocketAddr>, ipv6: bool) -> Result<Vec<(SocketAddr, Duration)>> {

--- a/mania/src/core/session.rs
+++ b/mania/src/core/session.rs
@@ -1,7 +1,7 @@
 use arc_swap::{ArcSwap, ArcSwapOption};
 use bytes::Bytes;
-use std::sync::atomic::{self, AtomicU16};
 use std::sync::Arc;
+use std::sync::atomic::{self, AtomicU16};
 
 pub struct Session {
     pub stub: KeyCollection,

--- a/mania/src/core/sign.rs
+++ b/mania/src/core/sign.rs
@@ -1,5 +1,5 @@
 use crate::core::context::Protocol;
-use phf::{phf_set, Set};
+use phf::{Set, phf_set};
 use serde::Deserialize;
 
 mod linux;

--- a/mania/src/core/tlv.rs
+++ b/mania/src/core/tlv.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use phf::{phf_map, Map};
+use phf::{Map, phf_map};
 use thiserror::Error;
 
 use crate::core::context::Context;
@@ -270,7 +270,7 @@ mod prelude {
     pub use crate::core::context::ExtendUuid;
     pub use crate::core::crypto::tea::tea_encrypt;
     pub use crate::core::packet::{PacketBuilder, PacketReader};
-    pub use crate::core::tlv::{serialize_tlv_set, TlvDe, TlvError, TlvSer};
+    pub use crate::core::tlv::{TlvDe, TlvError, TlvSer, serialize_tlv_set};
     pub use bytes::Bytes;
     pub use prost::Message;
     pub use uuid::Uuid;

--- a/mania/src/lib.rs
+++ b/mania/src/lib.rs
@@ -16,7 +16,7 @@ pub use crate::core::context::{AppInfo, Context, DeviceInfo};
 pub use crate::core::error::{Error, Result};
 pub use crate::core::key_store::KeyStore;
 use crate::core::session::Session;
-use crate::core::sign::{default_sign_provider, SignProvider};
+use crate::core::sign::{SignProvider, default_sign_provider};
 use std::env;
 use std::sync::Arc;
 

--- a/mania/src/message/entity/file.rs
+++ b/mania/src/message/entity/file.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::core::packet::{PacketReader, PREFIX_LENGTH_ONLY, PREFIX_U16};
+use crate::core::packet::{PREFIX_LENGTH_ONLY, PREFIX_U16, PacketReader};
 use std::fmt::Debug;
 
 #[derive(Default)]

--- a/mania/src/message/packer.rs
+++ b/mania/src/message/packer.rs
@@ -6,8 +6,8 @@ use crate::message::chain::{
     ClientSequence, FriendMessageUniqueElem, GroupMessageUniqueElem, MessageChain, MessageId,
     MessageType,
 };
-use crate::message::entity::file::{FileC2CUnique, FileEntity, FileUnique};
 use crate::message::entity::Entity;
+use crate::message::entity::file::{FileC2CUnique, FileEntity, FileUnique};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use prost::Message;

--- a/mania/src/utility/compress.rs
+++ b/mania/src/utility/compress.rs
@@ -1,7 +1,7 @@
 pub mod gzip {
+    use flate2::Compression;
     use flate2::read::GzDecoder;
     use flate2::write::GzEncoder;
-    use flate2::Compression;
     use std::io::{Read, Write};
 
     pub fn compress(data: &[u8]) -> Vec<u8> {
@@ -23,9 +23,9 @@ pub mod gzip {
 }
 
 pub mod zlib {
+    use flate2::Compression;
     use flate2::read::ZlibDecoder;
     use flate2::write::ZlibEncoder;
-    use flate2::Compression;
     use std::io::{Read, Write};
 
     pub fn compress(data: &[u8]) -> Vec<u8> {

--- a/mania/src/utility/def_default.rs
+++ b/mania/src/utility/def_default.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! dda {
-    ($struct:ident { $($field:ident $( : $value:expr )? ),* $(,)? }) => {
+    ($struct:ident { $($field:ident $( : $value:expr_2021 )? ),* $(,)? }) => {
         $struct {
             $(
                 $field: dda!(@value $field $( : $value )? )
@@ -9,7 +9,7 @@ macro_rules! dda {
         }
     };
 
-    (@value $field:ident : $value:expr) => {
+    (@value $field:ident : $value:expr_2021) => {
         $value
     };
 

--- a/mania/src/utility/def_default.rs
+++ b/mania/src/utility/def_default.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! dda {
-    ($struct:ident { $($field:ident $( : $value:expr_2021 )? ),* $(,)? }) => {
+    ($struct:ident { $($field:ident $( : $value:expr )? ),* $(,)? }) => {
         $struct {
             $(
                 $field: dda!(@value $field $( : $value )? )
@@ -9,7 +9,7 @@ macro_rules! dda {
         }
     };
 
-    (@value $field:ident : $value:expr_2021) => {
+    (@value $field:ident : $value:expr) => {
         $value
     };
 


### PR DESCRIPTION
as the title: bump rust `edition`: 2021 -> 2024.

just apply `cargo fix --edition`, `cargo clippy --fix` and `cargo fmt`.