### PR TITLE
chore: ask users to setup git hooks manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@
 
 [^1]: Only implemented event parsing
 
+## Development
+
+Make sure to set up the Git hooks before contributing by moving the hook files under
+`scripts` directory to `.git/hooks`:
+
+```bash
+mkdir -p .git/hooks
+cp scripts/pre-commit .git/hooks/pre-commit
+cp scripts/pre-push .git/hooks/pre-push
+```
+
+
 ## References
 
 - All projects in [LagrangeDev](https://github.com/lagrangeDev) (and their twin

--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@
 
 ## Development
 
-Make sure to set up the Git hooks before contributing by moving the hook files under
-`scripts` directory to `.git/hooks`:
+Make sure to set up the Git hooks before contributing by moving the hook files
+under `scripts` directory to `.git/hooks`:
 
 ```bash
 mkdir -p .git/hooks
 cp scripts/pre-commit .git/hooks/pre-commit
 cp scripts/pre-push .git/hooks/pre-push
 ```
-
 
 ## References
 

--- a/mania/build.rs
+++ b/mania/build.rs
@@ -1,15 +1,7 @@
 use anyhow::Result;
 use prost_build::Config;
-use std::path::Path;
 
 fn main() -> Result<()> {
-    if Path::new("../.git").is_dir() {
-        if !Path::new("../.git/hooks").exists() {
-            std::fs::create_dir_all(".././.git/hooks")?;
-        }
-        std::fs::copy("../scripts/pre-commit", "../.git/hooks/pre-commit")?;
-        std::fs::copy("../scripts/pre-push", "../.git/hooks/pre-push")?;
-    }
     let protos = glob::glob("src/core/protos/**/*.proto")?
         .map(|x| x.unwrap())
         .collect::<Vec<_>>();


### PR DESCRIPTION
Installing git hooks in the build script seems a bit too intrusive... When I tried to build this project in a sandbox environment, I was getting permission issues when writing to .git folders. For Windows users, the hook scripts actually does not work. When it's being used as a dependency, it could be tricky as well, hence I suggest making the hooks installation manual. A little bit of instructions have been added in the README.