### PR TITLE
chore: update dependencies & pin toolchain version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,5 @@ updates:
       interval: monthly
     # TODO: wait for refactor the related code
     ignore:
-      - dependency-name: rand
-      - dependency-name: rand_chacha
       - dependency-name: elliptic-curve
       - dependency-name: p256

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-
+newline_style = "Unix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -288,18 +288,9 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.11.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd016a0ddc7cb13661bf5576073ce07330a693f8608a1320b4e20561cc12cdc"
+checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
 dependencies = [
  "hybrid-array",
 ]
@@ -336,9 +327,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -381,9 +372,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -391,7 +382,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -418,8 +409,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.4",
  "tonic",
  "tracing-core",
 ]
@@ -437,8 +428,8 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.4",
  "serde",
  "serde_json",
  "thread_local",
@@ -452,15 +443,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ff6be19477a1bd5441f382916a89bc2a0b2c35db6d41e0f6e8538bf6d6463f"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "core-foundation"
@@ -498,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -538,58 +523,47 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "edaae5fb9dac79a07260e0b2006799ff4f1d342ab243fd7d0892215113b27904"
 dependencies = [
- "generic-array 0.14.7",
- "rand_core",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.9.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
 dependencies = [
- "generic-array 0.14.7",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b8ce8218c97789f16356e7896b3714f26c2ee1079b79c0b7ae7064bb9089fa"
-dependencies = [
- "getrandom 0.2.15",
  "hybrid-array",
- "rand_core",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "7.0.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e4a1e35a65fe0538a60167f0ada6e195ad5d477f6ddae273943596d4a1a5730b"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown 0.14.5",
+ "equivalent",
+ "hashbrown 0.15.2",
  "lock_api",
- "once_cell",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "0c2e6107818886eff6b71fba7a2da3dd11025ebb80f0c9b94ff961168ef629f2"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -605,25 +579,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
 dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.0-pre.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2e3d6615d99707295a9673e889bf363a04b2a466bd320c65a72536f7577379"
-dependencies = [
- "block-buffer 0.11.0-rc.3",
- "const-oid 0.10.0-rc.3",
- "crypto-common 0.2.0-rc.1",
 ]
 
 [[package]]
@@ -639,16 +602,17 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "f386592dae0cda5d4bf90836794e096ef74f06e84ec309ad3a7e81e1053a0d2e"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -659,20 +623,20 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "92ccc36f4cfd3b96979b66a2162a10052eb0b98c9241ed1498273c79898d26a7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
- "generic-array 0.14.7",
  "group",
  "hkdf",
+ "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.9.3",
  "sec1",
  "subtle",
  "zeroize",
@@ -741,11 +705,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
  "subtle",
 ]
 
@@ -757,9 +721,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -886,17 +850,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
-name = "generic-array"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c8444bc9d71b935156cc0ccab7f622180808af7867b1daae6547d773591703"
@@ -951,12 +904,12 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.9.3",
  "subtle",
 ]
 
@@ -997,12 +950,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1034,20 +981,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "6738bc5110ee31b066339f0c9454db29a93db3b0484bbf2afa8a7e9cebc62141"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "8dc6a2fcc35ab09136c6df2cdf9ca49790701420a3a6b5db0987dddbabc79b21"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1113,18 +1060,19 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1189,21 +1137,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1370,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.5"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6f44aed642f18953a158afeb30206f4d50da59fbc66ecb53c66488de73563b"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1440,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b12ebb6799019b044deaf431eadfe23245b259bba5a2c0796acec3943a3cdb"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
 ]
@@ -1452,6 +1407,16 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -1522,9 +1487,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1570,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loop9"
@@ -1589,16 +1554,15 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arc-swap",
- "block-buffer 0.11.0-rc.3",
  "byteorder",
  "bytes",
  "chrono",
  "dashmap",
- "digest 0.11.0-pre.9",
+ "digest",
  "elliptic-curve",
  "flate2",
  "futures",
- "generic-array 1.2.0",
+ "generic-array",
  "glob",
  "hex",
  "image",
@@ -1612,18 +1576,18 @@ dependencies = [
  "once_cell",
  "p256",
  "phf",
- "prost",
+ "prost 0.14.1",
  "prost-build",
  "quick-xml",
- "rand",
- "rand_chacha",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "sha1",
  "surge-ping",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1640,7 +1604,7 @@ dependencies = [
  "rubato",
  "silk-sys",
  "symphonia",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1695,12 +1659,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.11.0-pre.4"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117b97b6b9ae1ec9a396b357698efa3ecff4fc1f40e0ec59ae7c1270b460ac1d"
+checksum = "da1788e007bfe04177a520c827ef99f436b1ea79719d5c5f049279dfe85a7b28"
 dependencies = [
  "cfg-if",
- "digest 0.11.0-pre.9",
+ "digest",
 ]
 
 [[package]]
@@ -1784,7 +1748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_xorshift",
 ]
 
@@ -1911,15 +1875,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1949,9 +1913,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1967,12 +1931,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "10f895207881bb519f7e0746e5471f8a8b3ec01924008e8398b71b38bbf8d9ef"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "sha2",
 ]
@@ -2014,9 +1979,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
 dependencies = [
  "base64ct",
 ]
@@ -2039,29 +2004,30 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "d713258393a82f091ead52047ca779d37e5766226d009de21696c4e667044368"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2072,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -2113,9 +2079,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "3f1843d4345dfe1a55e487db747a04c01af50415b03e937410e0a41d8cc24ec7"
 dependencies = [
  "der",
  "spki",
@@ -2217,10 +2183,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "1bbeb92947a0d0d4b0cab5e2e6749acc44c81461eb3b1aff4dbb7acd0eb9f0ab"
+dependencies = [
+ "crypto-bigint",
+ "ff",
+ "rand_core 0.9.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceda4bcc4556f74ba324635498da05337996a0141ec3ba841d0b19c57e85b0d9"
 dependencies = [
  "elliptic-curve",
 ]
@@ -2236,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2269,14 +2248,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
  "itertools 0.13.0",
@@ -2285,8 +2274,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
  "regex",
  "syn",
  "tempfile",
@@ -2306,12 +2295,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -2331,9 +2342,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
  "serde",
@@ -2341,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2355,8 +2366,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2366,7 +2387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2379,12 +2410,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2413,8 +2453,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps",
  "thiserror 1.0.69",
@@ -2527,15 +2567,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2544,36 +2583,33 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "f53f124bf3ec90be84ae97d7f52175ba938898525554c13c9017eb8f0a604146"
 dependencies = [
  "hmac",
  "subtle",
@@ -2587,15 +2623,14 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "ed9b823fa29b721a59671b41d6b06e66b29e0628e207e8b1c3ceeda701ec928d"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2666,15 +2701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,13 +2746,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "e4855dd9b15e8e469fad23529698f7f7b7a6b250a81c88b1f9d7efe1abca7717"
 dependencies = [
  "base16ct",
  "der",
- "generic-array 0.14.7",
+ "hybrid-array",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -2757,18 +2783,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2777,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2810,24 +2836,24 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0-pre.4"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9540978cef7a8498211c1b1c14e5ce920fe5bd524ea84f4a3d72d4602515ae93"
+checksum = "6f9318facddf9ac32a33527066936837e189b3f23ced6edc1603720ead5e2b3d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-pre.9",
+ "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2856,12 +2882,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "b8852cecbd17ba45978bbbe43061ebe36a2ae376058c5c172e09f72888f8f7de"
 dependencies = [
- "digest 0.10.7",
- "rand_core",
+ "digest",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2915,25 +2941,19 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "c2f0e2bdca9b00f5be6dd3bb6647d50fd0f24a508a95f78e3bb2fe98d0403c85"
 dependencies = [
  "base64ct",
  "der",
@@ -2959,14 +2979,14 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surge-ping"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbf95ce4c7c5b311d2ce3f088af2b93edef0f09727fa50fbe03c7a979afce77"
+checksum = "6fda78103d8016bb25c331ddc54af634e801806463682cc3e549d335df644d95"
 dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet",
- "rand",
+ "rand 0.9.1",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -3152,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3246,11 +3266,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3266,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3339,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3399,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3464,7 +3484,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2",
  "tokio",
  "tokio-stream",
@@ -3485,7 +3505,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3505,6 +3525,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -3653,12 +3691,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.1",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3851,33 +3891,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ license-file = "LICENCE"
 readme = "README.md"
 
 [workspace.dependencies]
-md-5 = "0.11.0-pre.4"
+md-5 = "0.11.0-rc.0"
 hex = "0.4.3"
 tracing = "0.1.41"
-tokio = { version = "1.43.0", features = [
+tokio = { version = "1.45.1", features = [
   "fs",
   "net",
   "io-util",
@@ -22,10 +22,10 @@ tokio = { version = "1.43.0", features = [
   "signal",
   "tracing",
 ] }
-uuid = { version = "1.12.1", features = ["serde", "v4"] }
-thiserror = "2.0.11"
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
+thiserror = "2.0.12"
 num_enum = "0.7.3"
-bytes = { version = "1.10.0", features = ["serde"] }
+bytes = { version = "1.10.1", features = ["serde"] }
 
 [profile.release]
 opt-level = 2

--- a/examples/multi_login.rs
+++ b/examples/multi_login.rs
@@ -90,13 +90,11 @@ async fn main() {
                             None
                         }
                     };
-                    if let Some((chain_str, group_uin)) = maybe_data {
-                        if chain_str.contains("/mania ping") {
-                            let chain = MessageChainBuilder::group(group_uin)
-                                .text("pong")
-                                .build();
-                            send_op.send_message(chain).await.unwrap();
-                        }
+                    if let Some((chain_str, group_uin)) = maybe_data && chain_str.contains("/mania ping") {
+                        let chain = MessageChainBuilder::group(group_uin)
+                            .text("pong")
+                            .build();
+                        send_op.send_message(chain).await.unwrap();
                     }
                 }
             }
@@ -127,7 +125,7 @@ async fn main() {
         }
         .await;
         if let Err(e) = login_res {
-            panic!("Failed to login: {:?}", e);
+            panic!("Failed to login: {e:?}");
         }
     } else {
         tracing::info!("Session is still valid, trying to online...");
@@ -136,7 +134,7 @@ async fn main() {
     let _tx = match op.online().await {
         Ok(tx) => tx,
         Err(e) => {
-            panic!("Failed to set online status: {:?}", e);
+            panic!("Failed to set online status: {e:?}");
         }
     };
 

--- a/mania-codec/src/audio/encoder/silk_encoder.rs
+++ b/mania-codec/src/audio/encoder/silk_encoder.rs
@@ -27,7 +27,7 @@ pub enum SilkError {
 
 impl fmt::Display for SilkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/mania-macros/Cargo.toml
+++ b/mania-macros/Cargo.toml
@@ -8,8 +8,8 @@ license-file.workspace = true
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.98", features = ["full"] }
-quote = "1.0.38"
-proc-macro2 = "1.0.93"
+syn = { version = "2.0.103", features = ["full"] }
+quote = "1.0.40"
+proc-macro2 = "1.0.95"
 hex.workspace = true
 md-5.workspace = true

--- a/mania-macros/src/lib.rs
+++ b/mania-macros/src/lib.rs
@@ -30,6 +30,7 @@ pub fn pack_content(attr: TokenStream, item: TokenStream) -> TokenStream {
         true => {
             quote! {
                 #input_struct
+                #[automatically_derived]
                 impl crate::message::entity::MessageContentImplChecker for #ident {
                     fn need_pack(&self) -> bool {
                         true
@@ -40,11 +41,13 @@ pub fn pack_content(attr: TokenStream, item: TokenStream) -> TokenStream {
         false => {
             quote! {
                 #input_struct
+                #[automatically_derived]
                 impl crate::message::entity::MessageContentImplChecker for #ident {
                     fn need_pack(&self) -> bool {
                         true
                     }
                 }
+                #[automatically_derived]
                 impl crate::message::entity::MessageContentImpl for #ident {
                     fn pack_content(&self) -> Option<bytes::Bytes> {
                         None
@@ -64,6 +67,7 @@ pub fn command(attr: TokenStream, item: TokenStream) -> TokenStream {
     let ident = &input_struct.ident;
     let expanded = quote! {
         #input_struct
+        #[automatically_derived]
         impl crate::core::event::CECommandMarker for #ident {
             const COMMAND: &'static str = #command_value;
         }
@@ -110,6 +114,7 @@ pub fn oidb_command(attr: TokenStream, item: TokenStream) -> TokenStream {
     let ident = &input_struct.ident;
     let expanded = quote! {
         #input_struct
+        #[automatically_derived]
         impl crate::core::event::CECommandMarker for #ident {
             const COMMAND: &'static str = #command_value;
         }
@@ -128,6 +133,7 @@ pub fn derive_server_event(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let struct_name = input.ident;
     let expanded = quote! {
+        #[automatically_derived]
         impl crate::core::event::ServerEvent for #struct_name {
             fn as_any(&self) -> &dyn std::any::Any {
                 self
@@ -146,10 +152,12 @@ pub fn derive_dummy_event(input: TokenStream) -> TokenStream {
     let struct_name = &input.ident;
 
     let expanded = quote! {
+        #[automatically_derived]
         impl crate::core::event::CECommandMarker for #struct_name {
             const COMMAND: &'static str = "";
         }
 
+        #[automatically_derived]
         impl crate::core::event::ServerEvent for #struct_name {
             fn as_any(&self) -> &dyn std::any::Any {
                 self
@@ -159,6 +167,7 @@ pub fn derive_dummy_event(input: TokenStream) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl crate::core::event::ClientEvent for #struct_name {
             fn build(&self, _: &crate::core::context::Context) -> crate::core::event::CEBuildResult {
                 unreachable!("DummyEvent {} should not be parsed", stringify!(#struct_name));
@@ -200,9 +209,9 @@ pub fn handle_event(attr: TokenStream, item: TokenStream) -> TokenStream {
         let hash_value = hex::encode(hasher.finalize());
 
         let type_id_fn_name =
-            syn::Ident::new(&format!("_mhe_type_id_{}", hash_value), fn_name.span());
+            syn::Ident::new(&format!("_mhe_type_id_{hash_value}"), fn_name.span());
         let wrapper_fn_name =
-            syn::Ident::new(&format!("_mhe_wrap_id_{}", hash_value), fn_name.span());
+            syn::Ident::new(&format!("_mhe_wrap_id_{hash_value}"), fn_name.span());
 
         let trait_check = quote! {
             const _: () = {
@@ -282,18 +291,17 @@ pub fn derive_mania_event(input: proc_macro::TokenStream) -> proc_macro::TokenSt
                             .and_then(|attr| attr.parse_args::<ManiaEventPreferOptions>().ok())
                             .map_or_else(
                                 || {
-                                    if let syn::Type::Path(path) = field_type {
-                                        if let Some(segment) = path.path.segments.first() {
-                                            if segment.ident == "String" || segment.ident == "str" {
-                                                return "{}";
-                                            }
-                                        }
+                                    if let syn::Type::Path(path) = field_type
+                                        && let Some(segment) = path.path.segments.first()
+                                        && (segment.ident == "String" || segment.ident == "str")
+                                    {
+                                        return "{}";
                                     }
                                     "{:?}"
                                 },
                                 |opts| if opts.display { "{}" } else { "{:?}" },
                             );
-                        format!("{}: {}", field_name, placeholder)
+                        format!("{field_name}: {placeholder}")
                     })
                     .collect();
                 let fmt_string = format!("[{}] {}", struct_name, field_entries.join(" | "));
@@ -302,6 +310,7 @@ pub fn derive_mania_event(input: proc_macro::TokenStream) -> proc_macro::TokenSt
                     quote! { self.#field_ident }
                 });
                 quote! {
+                    #[automatically_derived]
                     impl std::fmt::Debug for #struct_name {
                         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                             write!(f, #fmt_string, #( #field_accesses ),* )

--- a/mania/Cargo.toml
+++ b/mania/Cargo.toml
@@ -9,43 +9,42 @@ edition.workspace = true
 mania-macros = { path = "../mania-macros" }
 mania-codec = { path = "../mania-codec" }
 arc-swap = { version = "1.7.1", features = ["serde"] }
-block-buffer = { version = "=0.11.0-rc.3" }                  # FIXME: This is a temporary solution, See: https://github.com/cot-rs/cot/issues/196
 byteorder = "1.5.0"
 bytes.workspace = true
-chrono = { version = "0.4.39", features = ["serde"] }
-dashmap = "6.1.0"
-flate2 = "1.1.0"
+chrono = { version = "0.4.41", features = ["serde"] }
+dashmap = "7.0.0-rc2"
+flate2 = "1.1.2"
 generic-array = "1.2.0"
-phf = { version = "0.11.3", features = ["macros"] }
-prost = "0.13.5"
-rand = "0.8.5"
-serde = { version = "1.0.217", features = ["derive"] }
-surge-ping = "0.8.1"
+phf = { version = "0.12.1", features = ["macros"] }
+prost = "0.14.1"
+rand = "0.9.1"
+serde = { version = "1.0.219", features = ["derive"] }
+surge-ping = "0.8.2"
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 hex.workspace = true
-reqwest = "0.12.12"
-serde_json = "1.0.139"
+reqwest = "0.12.20"
+serde_json = "1.0.140"
 futures = "0.3.31"
-inventory = "0.3.19"
-once_cell = "1.20.2"
-p256 = { version = "0.13.2", features = ["ecdh"] }
+inventory = "0.3.20"
+once_cell = "1.21.3"
+p256 = { version = "0.14.0-pre.6", features = ["ecdh"] }
 md-5.workspace = true
-elliptic-curve = "0.13.8"
-log = "0.4.26"
-rand_chacha = "0.3.1"
+elliptic-curve = "0.14.0-rc.6"
+log = "0.4.27"
+rand_chacha = "0.9.0"
 num_enum.workspace = true
-quick-xml = { version = "0.37.2", features = ["serialize"] }
+quick-xml = { version = "0.37.5", features = ["serialize"] }
 regex = "1.11.1"
-tokio-util = "0.7.13"
-sha1 = "0.11.0-pre.4"
-digest = "0.11.0-pre.9"
-image = "0.25.5"
+tokio-util = "0.7.15"
+sha1 = "0.11.0-rc.0"
+digest = "0.11.0-rc.0"
+image = "0.25.6"
 noise = "0.9.0"
 
 [build-dependencies]
-prost-build = "0.13.4"
+prost-build = "0.14.1"
 glob = "0.3.2"
-anyhow = "1.0.96"
+anyhow = "1.0.98"

--- a/mania/src/core/context.rs
+++ b/mania/src/core/context.rs
@@ -153,8 +153,8 @@ impl ExtendUuid for Uuid {
 
 impl Default for DeviceInfo {
     fn default() -> Self {
-        let mut rng = rand::thread_rng();
-        let mac_address: Vec<u8> = (0..6).map(|_| rng.r#gen()).collect();
+        let mut rng = rand::rng();
+        let mac_address: Vec<u8> = (0..6).map(|_| rng.random()).collect();
         Self {
             uuid: Uuid::new_v4(),
             mac_address,

--- a/mania/src/core/crypto/ecdh.rs
+++ b/mania/src/core/crypto/ecdh.rs
@@ -67,7 +67,7 @@ impl Ecdh for P256 {
     fn new(server_public_key: [u8; 65]) -> Self {
         let s_pub_key =
             PublicKey::from_sec1_bytes(&server_public_key).expect("Failed to parse public key");
-        let c_pri_key = EphemeralSecret::random(&mut rand::thread_rng());
+        let c_pri_key = EphemeralSecret::random(&mut rand::rng());
         let c_pub_key = c_pri_key.public_key();
         let share_key = Self::key_exchange(c_pri_key, s_pub_key)
             .expect("Failed to generate shared key from key exchange");
@@ -89,10 +89,10 @@ impl Ecdh for P256 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand::thread_rng;
+    use rand::rng;
     #[test]
     fn test_ecdh_p256() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let server_secret = EphemeralSecret::random(&mut rng);
         let server_public = server_secret.public_key();
         let client_secret = EphemeralSecret::random(&mut rng);
@@ -122,7 +122,7 @@ mod test {
             "Client message: {:?}",
             String::from_utf8_lossy(client_message)
         );
-        println!("Ciphertext from client: {:?}", ciphertext_from_client);
+        println!("Ciphertext from client: {ciphertext_from_client:?}");
         println!(
             "Decrypted by server: {:?}",
             String::from_utf8_lossy(&decrypted_by_server)
@@ -131,7 +131,7 @@ mod test {
             "Server message: {:?}",
             String::from_utf8_lossy(server_message)
         );
-        println!("Ciphertext from server: {:?}", ciphertext_from_server);
+        println!("Ciphertext from server: {ciphertext_from_server:?}");
         println!(
             "Decrypted by client: {:?}",
             String::from_utf8_lossy(&decrypted_by_client)

--- a/mania/src/core/crypto/stream_sha1.rs
+++ b/mania/src/core/crypto/stream_sha1.rs
@@ -4,7 +4,7 @@ use digest::{
     block_buffer::{BlockBuffer, Eager},
     typenum::{U64, Unsigned},
 };
-use sha1::compress;
+use sha1::block_api::compress;
 
 #[derive(Default)]
 struct StreamSha1Core {

--- a/mania/src/core/crypto/tea.rs
+++ b/mania/src/core/crypto/tea.rs
@@ -2,7 +2,7 @@
 use byteorder::{BigEndian, ByteOrder};
 pub use generic_array::GenericArray;
 pub use generic_array::typenum::U16;
-use rand::{RngCore, thread_rng};
+use rand::{RngCore, rng};
 
 pub fn tea_encrypt(text: &[u8], key: &[u8]) -> Vec<u8> {
     let fill_count = 9 - (text.len() + 1) % 8;
@@ -15,7 +15,7 @@ pub fn tea_encrypt(text: &[u8], key: &[u8]) -> Vec<u8> {
         //这里是为了和pytea对拍，填充220
         plaintext[1..fill_count + 1].fill(220);
     } else {
-        thread_rng().fill_bytes(&mut plaintext[1..fill_count + 1]);
+        rng().fill_bytes(&mut plaintext[1..fill_count + 1]);
     }
     plaintext[fill_count + 1..plaintext_len - 7].copy_from_slice(text);
 

--- a/mania/src/core/event/login/trans_emp.rs
+++ b/mania/src/core/event/login/trans_emp.rs
@@ -222,8 +222,7 @@ impl ClientEvent for TransEmp {
                     53 => TransEmp12Res::WaitingForConfirm,
                     54 => TransEmp12Res::Canceled,
                     _ => Err(EventError::OtherError(format!(
-                        "unknown trans_emp ret code: {}",
-                        state
+                        "unknown trans_emp ret code: {state}"
                     )))?,
                 };
                 Ok(ClientResult::single(Box::new(Self {
@@ -232,8 +231,7 @@ impl ClientEvent for TransEmp {
                 })))
             }
             _ => Err(EventError::OtherError(format!(
-                "unsupported trans_emp command: {:#x}",
-                command
+                "unsupported trans_emp command: {command:#x}"
             )))?,
         }
     }

--- a/mania/src/core/event/message/push_msg.rs
+++ b/mania/src/core/event/message/push_msg.rs
@@ -139,7 +139,7 @@ impl ClientEvent for PushMessageEvent {
             .map(|content_head| content_head.r#type)
             .ok_or_else(|| EventError::OtherError("Cannot get typ in PushMsg".to_string()))?;
         let packet_type = PkgType::try_from(typ).map_err(|_| {
-            EventError::InternalWarning(format!("receive unknown olpush message type: {:?}", typ))
+            EventError::InternalWarning(format!("receive unknown olpush message type: {typ:?}"))
         })?;
         let mut chain: Option<MessageChain> = None;
         let mut extra: Option<Vec<Box<dyn ServerEvent>>> = match packet_type {
@@ -161,7 +161,7 @@ impl ClientEvent for PushMessageEvent {
                         })?,
                         ctx,
                     )
-                    .map_err(|e| EventError::OtherError(format!("parse_chain failed: {}", e)))?,
+                    .map_err(|e| EventError::OtherError(format!("parse_chain failed: {e}")))?,
                 );
             }
             PkgType::PrivateFileMessage => {
@@ -172,9 +172,7 @@ impl ClientEvent for PushMessageEvent {
                         })?,
                         ctx,
                     )
-                    .map_err(|e| {
-                        EventError::OtherError(format!("parse_file_chain failed: {}", e))
-                    })?,
+                    .map_err(|e| EventError::OtherError(format!("parse_file_chain failed: {e}")))?,
                 )
             }
             PkgType::GroupRequestInvitationNotice => {
@@ -270,8 +268,7 @@ impl ClientEvent for PushMessageEvent {
                     .transpose()
                     .map_err(|e| {
                         EventError::OtherError(format!(
-                            "Failed to parse invitor_uid in GroupChange: {}",
-                            e
+                            "Failed to parse invitor_uid in GroupChange: {e}"
                         ))
                     })?;
                 extra
@@ -429,8 +426,7 @@ fn process_event_0x2dc<'a>(
 ) -> Result<&'a mut Option<Vec<Box<dyn ServerEvent>>>, EventError> {
     let sub_type = Event0x2DCSubType::try_from(extract_0x_sub_type(packet)?).map_err(|err| {
         EventError::InternalWarning(format!(
-            "receive unknown olpush message 0x2dc sub type: {:?}",
-            err
+            "receive unknown olpush message 0x2dc sub type: {err:?}"
         ))
     })?;
     match sub_type {
@@ -471,8 +467,7 @@ fn process_event_0x2dc<'a>(
             let ev = Event0x2DCSubType16Field13::try_from(msg_body.field13.unwrap_or_default())
                 .map_err(|e| {
                     EventError::InternalWarning(format!(
-                        "Failed to parse 0x2dc sub type 16 field 13: {}",
-                        e
+                        "Failed to parse 0x2dc sub type 16 field 13: {e}"
                     ))
                 })?;
             match ev {
@@ -622,8 +617,7 @@ fn process_event_0x210<'a>(
 ) -> Result<&'a mut Option<Vec<Box<dyn ServerEvent>>>, EventError> {
     let sub_type = Event0x210SubType::try_from(extract_0x_sub_type(packet)?).map_err(|err| {
         EventError::InternalWarning(format!(
-            "receive unknown olpush message 0x210 sub type: {:?}",
-            err
+            "receive unknown olpush message 0x210 sub type: {err:?}"
         ))
     })?;
     match sub_type {
@@ -832,8 +826,7 @@ fn process_event_0x210<'a>(
         }
         Event0x210SubType::ServicePinChanged | Event0x210SubType::GroupKickNotice => {
             Err(EventError::InternalWarning(format!(
-                "TODO: handle 0x210 sub type {:?}",
-                sub_type
+                "TODO: handle 0x210 sub type {sub_type:?}"
             )))?;
         }
     }

--- a/mania/src/core/highway.rs
+++ b/mania/src/core/highway.rs
@@ -22,7 +22,7 @@ fn int32ip2str(ip: u32) -> String {
     let b = (ip >> 8) & 0xff;
     let c = (ip >> 16) & 0xff;
     let d = (ip >> 24) & 0xff;
-    format!("{}.{}.{}.{}", a, b, c, d)
+    format!("{a}.{b}.{c}.{d}")
 }
 
 pub fn oidb_ipv4s_to_highway_ipv4s(ipv4s: &[IPv4]) -> Vec<NtHighwayIPv4> {

--- a/mania/src/core/highway/hw_client.rs
+++ b/mania/src/core/highway/hw_client.rs
@@ -144,7 +144,7 @@ impl HighwayClient {
         let mut buf = BytesMut::new();
         let mut codec = HighwayFrameCodec;
         codec.encode(frame, &mut buf).map_err(|e| {
-            HighwayError::OtherError(format!("encode http frame failed: {}", e).into())
+            HighwayError::OtherError(format!("encode http frame failed: {e}").into())
         })?;
         let mut codec = HighwayFrameCodec;
         let mut res_buf = BytesMut::from(buf.as_ref() as &[u8]);
@@ -244,7 +244,7 @@ impl HighwayClient {
             let mut codec = HighwayFrameCodec;
             let mut encoded_buf = BytesMut::new();
             codec.encode(frame, &mut encoded_buf).map_err(|e| {
-                HighwayError::OtherError(format!("encode http frame failed: {}", e).into())
+                HighwayError::OtherError(format!("encode http frame failed: {e}").into())
             })?;
             let post_frame = encoded_buf.freeze();
             let headers = [
@@ -274,10 +274,9 @@ impl HighwayClient {
                 )
                 .await
                 .map_err(|e| {
-                    HighwayError::OtherError(Cow::from(format!(
-                        "Failed to upload via http: {:?}",
-                        e
-                    )))
+                    HighwayError::OtherError(Cow::from(
+                        format!("Failed to upload via http: {e:?}",),
+                    ))
                 })?;
             let mut res_buf = BytesMut::from(res.as_ref() as &[u8]);
             let mut codec = HighwayFrameCodec;

--- a/mania/src/core/operation/highway_op.rs
+++ b/mania/src/core/operation/highway_op.rs
@@ -84,7 +84,7 @@ impl BusinessHandle {
                 })
                 .await?;
                 let iv = resolve_image_metadata(s).await.map_err(|e| {
-                    ManiaError::GenericError(Cow::from(format!("Resolve image error: {:?}", e)))
+                    ManiaError::GenericError(Cow::from(format!("Resolve image error: {e:?}")))
                 })?;
                 let sha1_bytes = Bytes::from(sha1_hasher.finalize().to_vec());
                 let md5_bytes = Bytes::from(md5_hasher.finalize().to_vec());
@@ -323,7 +323,7 @@ impl BusinessHandle {
     ) -> ManiaResult<()> {
         self.prepare_highway().await?;
         let (vs, is) = video.resolve_stream().await.map_err(|e| {
-            ManiaError::GenericError(Cow::from(format!("Resolve stream error: {:?}", e)))
+            ManiaError::GenericError(Cow::from(format!("Resolve stream error: {e:?}")))
         })?;
         let vs = vs.ok_or(ManiaError::GenericError(Cow::from("No video stream found")))?;
         let is = is.ok_or(ManiaError::GenericError(Cow::from("No image stream found")))?;
@@ -469,7 +469,7 @@ impl BusinessHandle {
     ) -> ManiaResult<()> {
         self.prepare_highway().await?;
         let (vs, is) = video.resolve_stream().await.map_err(|e| {
-            ManiaError::GenericError(Cow::from(format!("Resolve stream error: {:?}", e)))
+            ManiaError::GenericError(Cow::from(format!("Resolve stream error: {e:?}")))
         })?;
         let vs = vs.ok_or(ManiaError::GenericError(Cow::from("No video stream found")))?;
         let is = is.ok_or(ManiaError::GenericError(Cow::from("No image stream found")))?;
@@ -627,31 +627,24 @@ impl BusinessHandle {
                         let pipeline = AudioRwStream::new(Box::new(cursor))
                             .decode(SymphoniaDecoder::<f32>::new())
                             .map_err(|e| {
-                                ManiaError::GenericError(Cow::from(format!(
-                                    "Decode error: {:?}",
-                                    e
-                                )))
+                                ManiaError::GenericError(Cow::from(format!("Decode error: {e:?}")))
                             })?
                             .resample(RubatoResampler::<i16>::new(48000))
                             .map_err(|e| {
                                 ManiaError::GenericError(Cow::from(format!(
-                                    "Resample error: {:?}",
-                                    e
+                                    "Resample error: {e:?}",
                                 )))
                             })?
                             .encode(SilkEncoder::new(30000))
                             .map_err(|e| {
-                                ManiaError::GenericError(Cow::from(format!(
-                                    "Encode error: {:?}",
-                                    e
-                                )))
+                                ManiaError::GenericError(Cow::from(format!("Encode error: {e:?}",)))
                             })?;
                         tracing::debug!("Audio processing finished");
                         let output = pipeline.stream;
                         Ok::<Vec<u8>, ManiaError>(output)
                     });
                     let res = task.await.map_err(|e| {
-                        ManiaError::GenericError(Cow::from(format!("Blocking error: {:?}", e)))
+                        ManiaError::GenericError(Cow::from(format!("Blocking error: {e:?}")))
                     })??;
                     let get_ten_silk_time = |data: &[u8]| -> f64 {
                         let mut i = 10;

--- a/mania/src/core/operation/wt_op.rs
+++ b/mania/src/core/operation/wt_op.rs
@@ -61,8 +61,7 @@ impl BusinessHandle {
             };
             let payload = serde_json::to_vec(&request_body).map_err(|e| {
                 ManiaError::GenericError(Cow::from(format!(
-                    "Failed to serialize request body: {:?}",
-                    e
+                    "Failed to serialize request body: {e:?}",
                 )))
             })?;
             let mut headers = reqwest::header::HeaderMap::new();
@@ -75,14 +74,12 @@ impl BusinessHandle {
                 .await
                 .map_err(|e| {
                     ManiaError::GenericError(Cow::from(format!(
-                        "Failed to query QR code status via ntlogin.qq.com: {:?}",
-                        e
+                        "Failed to query QR code status via ntlogin.qq.com: {e:?}",
                     )))
                 })?;
             let info: NTLoginHttpResponse = serde_json::from_slice(&response).map_err(|e| {
                 ManiaError::GenericError(Cow::from(format!(
-                    "Failed to deserialize response: {:?}",
-                    e
+                    "Failed to deserialize response: {e:?}",
                 )))
             })?;
             self.context.key_store.uin.store(info.uin.into());

--- a/mania/src/core/packet.rs
+++ b/mania/src/core/packet.rs
@@ -166,7 +166,7 @@ impl SsoPacket {
 
         // Initialize the sequence number
         if SEQUENCE.compare_exchange(0, 1, Release, Acquire).is_ok() {
-            let offset = rand::thread_rng().gen_range(5000000..=9900000);
+            let offset = rand::rng().random_range(5000000..=9900000);
             SEQUENCE.store(offset, Relaxed);
         } else {
             // Other threads are doing the initialization
@@ -407,16 +407,16 @@ pub enum PacketError {
 fn random_trace() -> String {
     use std::fmt::Write;
     let mut result = String::from("00-");
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // 32 digits
     for _ in 0..16 {
-        write!(result, "{:x}", rng.r#gen::<u8>()).unwrap();
+        write!(result, "{:x}", rng.random::<u8>()).unwrap();
     }
     result.push('-');
     // 16 digits
     for _ in 0..8 {
-        write!(result, "{:x}", rng.r#gen::<u8>()).unwrap();
+        write!(result, "{:x}", rng.random::<u8>()).unwrap();
     }
     result.push_str("-01");
 

--- a/mania/src/entity/bot_friend.rs
+++ b/mania/src/entity/bot_friend.rs
@@ -36,7 +36,7 @@ impl BotFriend {
             personal_sign,
             qid,
             group,
-            avatar: format!("https://q1.qlogo.cn/g?b=qq&nk={}&s=640", uin),
+            avatar: format!("https://q1.qlogo.cn/g?b=qq&nk={uin}&s=640"),
         }
     }
 }

--- a/mania/src/entity/sys_face.rs
+++ b/mania/src/entity/sys_face.rs
@@ -75,7 +75,7 @@ impl SysFacePackEntry {
             .map(|e| {
                 e.q_sid
                     .parse::<u32>()
-                    .map_err(|e| format!("Failed to parse q_sid to u32: {}", e))
+                    .map_err(|e| format!("Failed to parse q_sid to u32: {e}"))
             })
             .collect()
     }

--- a/mania/src/lib.rs
+++ b/mania/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(default_field_values)]
+#![feature(result_flattening)]
 
 mod core;
 pub mod entity;

--- a/mania/src/lib.rs
+++ b/mania/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(default_field_values)]
-#![feature(result_flattening)]
 
 mod core;
 pub mod entity;

--- a/mania/src/message/chain.rs
+++ b/mania/src/message/chain.rs
@@ -85,10 +85,10 @@ impl Debug for MessageChain {
         let entities_preview = self
             .entities
             .iter()
-            .map(|entity| format!("{:?}", entity))
+            .map(|entity| format!("{entity:?}"))
             .collect::<Vec<String>>()
             .join(" | ");
-        write!(f, "{}{}", header, entities_preview)
+        write!(f, "{header}{entities_preview}")
     }
 }
 
@@ -98,7 +98,7 @@ impl Debug for MessageChain {
 impl Display for MessageChain {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         for entity in &self.entities {
-            write!(f, "{}", entity)?;
+            write!(f, "{entity}")?;
         }
         Ok(())
     }

--- a/mania/src/message/entity/image.rs
+++ b/mania/src/message/entity/image.rs
@@ -100,31 +100,30 @@ impl MessageEntity for ImageEntity {
     }
 
     fn unpack_element(elem: &Elem) -> Option<Self> {
-        if let Some(common) = &elem.common_elem {
-            if common.service_type == 48
-                && (common.business_type == 10 || common.business_type == 20)
-            {
-                let extra: MsgInfo = MsgInfo::decode(&*common.pb_elem).ok()?;
-                let ext_biz_info = extra.ext_biz_info.as_ref()?;
-                let msg_info_body = &extra.msg_info_body[0];
-                let index = msg_info_body.index.as_ref()?;
+        if let Some(common) = &elem.common_elem
+            && common.service_type == 48
+            && (common.business_type == 10 || common.business_type == 20)
+        {
+            let extra: MsgInfo = MsgInfo::decode(&*common.pb_elem).ok()?;
+            let ext_biz_info = extra.ext_biz_info.as_ref()?;
+            let msg_info_body = &extra.msg_info_body[0];
+            let index = msg_info_body.index.as_ref()?;
 
-                return Some(dda!(ImageEntity {
-                    height: index.info.as_ref()?.height,
-                    width: index.info.as_ref()?.width,
-                    file_path: Some(index.info.as_ref()?.file_name.clone()),
-                    md5: Bytes::from(index.info.as_ref()?.file_hash.unhex().ok()?),
-                    size: index.info.as_ref()?.file_size,
-                    msg_info: Some(extra.clone()),
-                    sub_type: ext_biz_info.pic.as_ref()?.biz_type,
-                    is_group: ext_biz_info.pic.as_ref()?.bytes_pb_reserve_troop.is_some(), // TODO: check this
-                    summary: if ext_biz_info.pic.as_ref()?.text_summary.is_empty() {
-                        Some("[图片]".to_string())
-                    } else {
-                        Some(ext_biz_info.pic.as_ref()?.text_summary.clone())
-                    },
-                }));
-            }
+            return Some(dda!(ImageEntity {
+                height: index.info.as_ref()?.height,
+                width: index.info.as_ref()?.width,
+                file_path: Some(index.info.as_ref()?.file_name.clone()),
+                md5: Bytes::from(index.info.as_ref()?.file_hash.unhex().ok()?),
+                size: index.info.as_ref()?.file_size,
+                msg_info: Some(extra.clone()),
+                sub_type: ext_biz_info.pic.as_ref()?.biz_type,
+                is_group: ext_biz_info.pic.as_ref()?.bytes_pb_reserve_troop.is_some(), // TODO: check this
+                summary: if ext_biz_info.pic.as_ref()?.text_summary.is_empty() {
+                    Some("[图片]".to_string())
+                } else {
+                    Some(ext_biz_info.pic.as_ref()?.text_summary.clone())
+                },
+            }));
         }
 
         if let Some(image) = &elem.not_online_image {

--- a/mania/src/message/packer.rs
+++ b/mania/src/message/packer.rs
@@ -285,7 +285,7 @@ impl MessagePacker {
 
         let mut base_chain = MessagePacker::parse_chain(body, ctx)?;
         let extra = FileExtra::decode(Bytes::from(msg_content))
-            .map_err(|e| format!("failed to decode FileExtra: {:?}", e))?;
+            .map_err(|e| format!("failed to decode FileExtra: {e:?}"))?;
         let file = extra
             .file
             .as_ref()

--- a/mania/src/utility/random_gen.rs
+++ b/mania/src/utility/random_gen.rs
@@ -7,9 +7,9 @@ static RNG: OnceLock<Mutex<ChaCha12Rng>> = OnceLock::new();
 
 impl RandomGenerator {
     pub fn random_num(start: u32, end: u32) -> u32 {
-        let rng_mutex = RNG.get_or_init(|| Mutex::new(ChaCha12Rng::from_entropy()));
+        let rng_mutex = RNG.get_or_init(|| Mutex::new(ChaCha12Rng::seed_from_u64(0)));
         let mut rng = rng_mutex.lock().expect("Failed to lock RNG mutex");
-        rng.gen_range(start..=end)
+        rng.random_range(start..=end)
     }
 
     pub fn rand_u32() -> u32 {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-02-10"
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-02-10"
+channel = "nightly-2025-06-01"
 profile = "default"

--- a/typos.toml
+++ b/typos.toml
@@ -3,3 +3,5 @@ ignore-hidden = false
 [default]
 check-filename = true
 check-file = true
+[default.extend-words]
+typ = "typ"


### PR DESCRIPTION
- Specify nightly toolchain with a date to make sure non-nix users get a functional-reproducible build
- `result_flattening` has been stabilized in today's toolchain
- Update rustfmt config to keep cross-platform consistent line endings